### PR TITLE
Use correct git URLs to improve package resolution

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
             targets: ["OpenAPIReflection"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/mattpolzin/OpenAPIKit", from: "1.0.0"),
-        .package(url: "https://github.com/mattpolzin/Sampleable", from: "2.1.0")
+        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "1.0.0"),
+        .package(url: "https://github.com/mattpolzin/Sampleable.git", from: "2.1.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Adding .git is the recommended way to specify Github dependencies and is consistent with your other OpenAPIKit packages. Without it it seems SPM sometimes has difficulty resolving if there are multiple package in the dependency hierarchy that rely on OpenAPIKit using different "spellings" of the URL.