### PR TITLE
fix a bug where optional types wrapping opaque structs did not reflect to schemas correctly.

### DIFF
--- a/Tests/OpenAPIReflectionTests/GenericOpenAPISchemaInternalTests.swift
+++ b/Tests/OpenAPIReflectionTests/GenericOpenAPISchemaInternalTests.swift
@@ -24,6 +24,7 @@ final class GenericOpenAPISchemaInternalTests: XCTestCase {
         XCTAssertEqual(try openAPISchemaGuess(for: Double.self, using: testEncoder), .number(format: .double))
         XCTAssertEqual(try openAPISchemaGuess(for: Bool.self, using: testEncoder), .boolean)
         XCTAssertEqual(try openAPISchemaGuess(for: TestEnum.self, using: testEncoder), .string)
+        XCTAssertEqual(try openAPISchemaGuess(for: Optional<String>.self, using: testEncoder), .string(required: false))
     }
 
     func test_openAPINodeGuessForValue() {
@@ -33,6 +34,7 @@ final class GenericOpenAPISchemaInternalTests: XCTestCase {
         XCTAssertEqual(try openAPISchemaGuess(for: 11.5, using: testEncoder), .number(format: .double))
         XCTAssertEqual(try openAPISchemaGuess(for: true, using: testEncoder), .boolean)
         XCTAssertEqual(try openAPISchemaGuess(for: TestEnum.one, using: testEncoder), .string)
+        XCTAssertEqual(try openAPISchemaGuess(for: Optional("hello") as Any, using: testEncoder), .string(required: false))
     }
 }
 

--- a/Tests/OpenAPIReflectionTests/GenericOpenAPISchemaTests.swift
+++ b/Tests/OpenAPIReflectionTests/GenericOpenAPISchemaTests.swift
@@ -36,10 +36,27 @@ final class GenericOpenAPISchemaTests: XCTestCase {
                     "int": .integer,
                     "double": .number(format: .double),
                     "float": .number(format: .float),
-                    "bool": .boolean
+                    "bool": .boolean,
+                    "optionalString": .string(required: false)
                 ]
             )
        )
+    }
+
+    func test_opaqueStruct() throws {
+        // "opaque" in that the `OnlyCodable` type does not itself define an OpenAPI schema and so we must
+        // encode it to have any chance at guessing its structure.
+        let node = try OpaqueStructs.genericOpenAPISchemaGuess(using: JSONEncoder())
+
+        XCTAssertEqual(
+            node,
+            JSONSchema.object(
+                properties: [
+                    "opaque": .object(properties: ["value": .string]),
+                    "optionalOpaque": .object(required: false, properties: ["value": .string])
+                ]
+            )
+        )
     }
 
     func test_dateType() throws {
@@ -281,8 +298,25 @@ extension GenericOpenAPISchemaTests {
         let double: Double
         let float: Float
         let bool: Bool
+        let optionalString: String?
 
-        static let sample: BasicTypes = .init(string: "hello", int: 10, double: 2.3, float: 1.1, bool: true)
+        static let sample: BasicTypes = .init(string: "hello", int: 10, double: 2.3, float: 1.1, bool: true, optionalString: "world")
+    }
+
+    struct OnlyCodable: Codable {
+        let value: String
+    }
+
+    struct OpaqueStructs: Codable, Sampleable {
+        // "opaque" in that the `OnlyCodable` type does not itself define an OpenAPI schema and so we must
+        // encode it to have any chance at guessing its structure.
+        let opaque: OnlyCodable
+        let optionalOpaque: OnlyCodable?
+
+        static let sample: OpaqueStructs = .init(
+            opaque: .init(value: "hello"),
+            optionalOpaque: .init(value: "world")
+        )
     }
 
     struct DateType: Codable, Sampleable {


### PR DESCRIPTION
There was a bug where if a type that does not define its OpenAPI schema explicitly was wrapped in an `Optional` and then set as a property of some type for which a `genericOpenAPISchemaGuess()` was requested then the generic schema guess would result in the optional being represented as an explicit `"some"` key in the schema instead of just making the type it wraps optional.

This PR fixes that bug by short-circuiting the normal schema guessing logic in the case of `Optional` values. Enumerations (of which `Optional` is one) will result in "children" for each `case` when they are mirrored, so we want to handle `Optional` specially since we know it does not encode in the default way for enumerations and instead has special semantics.