### PR TITLE
Fixing issue with Swift 6.0 and DateEncodingStrategy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   linux:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,21 +13,16 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - swift:5.8-bionic
           - swift:5.8-focal
           - swift:5.8-jammy
-          - swift:5.8-amazonlinux2
           - swift:5.9-focal
           - swift:5.9-jammy
-          - swift:5.9-amazonlinux2
           - swift:5.10-focal
           - swift:5.10-jammy
           - swift:5.10-noble
-          - swift:5.10-amazonlinux2
           - swift:6.0-focal
           - swift:6.0-jammy
           - swift:6.0-noble
-          - swift:6.0-amazonlinux2
     container: 
       image: ${{ matrix.image }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
       image: ${{ matrix.image }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
     - name: Run tests
       run: swift test --enable-test-discovery
   osx:
@@ -42,6 +42,6 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with: { 'xcode-version': 'latest' }
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Run tests
         run: swift test --enable-test-discovery

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,14 @@ jobs:
           - swift:5.9-focal
           - swift:5.9-jammy
           - swift:5.9-amazonlinux2
+          - swift:5.10-focal
+          - swift:5.10-jammy
+          - swift:5.10-noble
+          - swift:5.10-amazonlinux2
+          - swift:6.0-focal
+          - swift:6.0-jammy
+          - swift:6.0-noble
+          - swift:6.0-amazonlinux2
     container: ${{ matrix.image }}
     steps:
     - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,8 @@ jobs:
           - swift:6.0-jammy
           - swift:6.0-noble
           - swift:6.0-amazonlinux2
-    container: ${{ matrix.image }}
+    container: 
+      image: ${{ matrix.image }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     container: ${{ matrix.image }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Run tests
       run: swift test --enable-test-discovery
   osx:
@@ -41,6 +41,6 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with: { 'xcode-version': 'latest' }
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run tests
         run: swift test --enable-test-discovery

--- a/Sources/OpenAPIReflection/Date+OpenAPI.swift
+++ b/Sources/OpenAPIReflection/Date+OpenAPI.swift
@@ -25,11 +25,13 @@ extension Date: DateOpenAPISchemaType {
 		case .iso8601:
 			return .string(format: .dateTime)
 
+		#if !canImport(FoundationEssentials) || swift(<5.10)
 		case .formatted(let formatter):
 			let hasTime = formatter.timeStyle != .none
 			let format: JSONTypeFormat.StringFormat = hasTime ? .dateTime : .date
 
 			return .string(format: format)
+		#endif
 
         @unknown default:
             return nil

--- a/Sources/OpenAPIReflection30/Date+OpenAPI.swift
+++ b/Sources/OpenAPIReflection30/Date+OpenAPI.swift
@@ -8,6 +8,8 @@
 import Foundation
 import OpenAPIKit30
 
+
+
 extension Date: DateOpenAPISchemaType {
 	public static func dateOpenAPISchemaGuess(using encoder: JSONEncoder) -> JSONSchema? {
 
@@ -25,11 +27,13 @@ extension Date: DateOpenAPISchemaType {
 		case .iso8601:
 			return .string(format: .dateTime)
 
+	#if !canImport(FoundationEssentials) || swift(<5.10)
 		case .formatted(let formatter):
 			let hasTime = formatter.timeStyle != .none
 			let format: JSONTypeFormat.StringFormat = hasTime ? .dateTime : .date
 
 			return .string(format: format)
+	#endif
 
         @unknown default:
             return nil

--- a/Sources/OpenAPIReflection30/Date+OpenAPI.swift
+++ b/Sources/OpenAPIReflection30/Date+OpenAPI.swift
@@ -8,8 +8,6 @@
 import Foundation
 import OpenAPIKit30
 
-
-
 extension Date: DateOpenAPISchemaType {
 	public static func dateOpenAPISchemaGuess(using encoder: JSONEncoder) -> JSONSchema? {
 

--- a/Tests/OpenAPIReflection30Tests/GenericOpenAPISchemaTests.swift
+++ b/Tests/OpenAPIReflection30Tests/GenericOpenAPISchemaTests.swift
@@ -98,7 +98,9 @@ final class GenericOpenAPISchemaTests: XCTestCase {
         let df1 = DateFormatter()
         df1.timeStyle = .none
         e4.dateEncodingStrategy = .formatted(df1)
-
+        #if os(Linux)
+        throw XCTSkip("Not supported on Linux.")
+        #else        
         let node4 = try DateType.genericOpenAPISchemaGuess(using: e4)
 
         XCTAssertEqual(
@@ -125,6 +127,7 @@ final class GenericOpenAPISchemaTests: XCTestCase {
                 ]
             )
         )
+        #endif
     }
 
     func test_nested() throws {

--- a/Tests/OpenAPIReflection30Tests/GenericOpenAPISchemaTests.swift
+++ b/Tests/OpenAPIReflection30Tests/GenericOpenAPISchemaTests.swift
@@ -98,8 +98,8 @@ final class GenericOpenAPISchemaTests: XCTestCase {
         let df1 = DateFormatter()
         df1.timeStyle = .none
         e4.dateEncodingStrategy = .formatted(df1)
-        #if os(Linux)
-        throw XCTSkip("Not supported on Linux.")
+        #if canImport(FoundationEssentials) && swift(>=5.10)
+        throw XCTSkip("Not supported for Swift 5.10+ on Linux.")
         #else        
         let node4 = try DateType.genericOpenAPISchemaGuess(using: e4)
 

--- a/Tests/OpenAPIReflectionTests/GenericOpenAPISchemaTests.swift
+++ b/Tests/OpenAPIReflectionTests/GenericOpenAPISchemaTests.swift
@@ -102,8 +102,8 @@ final class GenericOpenAPISchemaTests: XCTestCase {
         let node3 = try DateType.genericOpenAPISchemaGuess(using: e3)
 
         XCTAssertEqual(node2, node3)
-        #if os(Linux)
-        throw XCTSkip("Not supported on Linux.")
+        #if canImport(FoundationEssentials) && swift(>=5.10)
+        throw XCTSkip("Not supported for Swift 5.10+ on Linux.")
         #else
         XCTAssertEqual(
             node2,

--- a/Tests/OpenAPIReflectionTests/GenericOpenAPISchemaTests.swift
+++ b/Tests/OpenAPIReflectionTests/GenericOpenAPISchemaTests.swift
@@ -102,46 +102,50 @@ final class GenericOpenAPISchemaTests: XCTestCase {
         let node3 = try DateType.genericOpenAPISchemaGuess(using: e3)
 
         XCTAssertEqual(node2, node3)
-        XCTAssertEqual(
-            node2,
-            JSONSchema.object(
-                properties: [
-                    "date": .number(format: .double)
-                ]
-            )
-        )
+        #if os(Linux)
+          throw XCTSkip("Not supported on Linux.")
+        #else
+          XCTAssertEqual(
+              node2,
+              JSONSchema.object(
+                  properties: [
+                      "date": .number(format: .double)
+                  ]
+              )
+          )
 
-        let e4 = JSONEncoder()
-        let df1 = DateFormatter()
-        df1.timeStyle = .none
-        e4.dateEncodingStrategy = .formatted(df1)
+          let e4 = JSONEncoder()
+          let df1 = DateFormatter()
+          df1.timeStyle = .none
+          e4.dateEncodingStrategy = .formatted(df1)
 
-        let node4 = try DateType.genericOpenAPISchemaGuess(using: e4)
+          let node4 = try DateType.genericOpenAPISchemaGuess(using: e4)
 
-        XCTAssertEqual(
-            node4,
-            JSONSchema.object(
-                properties: [
-                    "date": .string(format: .date)
-                ]
-            )
-        )
+          XCTAssertEqual(
+              node4,
+              JSONSchema.object(
+                  properties: [
+                      "date": .string(format: .date)
+                  ]
+              )
+          )
 
-        let e5 = JSONEncoder()
-        let df2 = DateFormatter()
-        df2.timeStyle = .full
-        e5.dateEncodingStrategy = .formatted(df2)
+          let e5 = JSONEncoder()
+          let df2 = DateFormatter()
+          df2.timeStyle = .full
+          e5.dateEncodingStrategy = .formatted(df2)
 
-        let node5 = try DateType.genericOpenAPISchemaGuess(using: e5)
+          let node5 = try DateType.genericOpenAPISchemaGuess(using: e5)
 
-        XCTAssertEqual(
-            node5,
-            JSONSchema.object(
-                properties: [
-                    "date": .string(format: .dateTime)
-                ]
-            )
-        )
+          XCTAssertEqual(
+              node5,
+              JSONSchema.object(
+                  properties: [
+                      "date": .string(format: .dateTime)
+                  ]
+              )
+          )
+      #endif
     }
 
     func test_nested() throws {

--- a/Tests/OpenAPIReflectionTests/GenericOpenAPISchemaTests.swift
+++ b/Tests/OpenAPIReflectionTests/GenericOpenAPISchemaTests.swift
@@ -103,49 +103,49 @@ final class GenericOpenAPISchemaTests: XCTestCase {
 
         XCTAssertEqual(node2, node3)
         #if os(Linux)
-          throw XCTSkip("Not supported on Linux.")
+        throw XCTSkip("Not supported on Linux.")
         #else
-          XCTAssertEqual(
-              node2,
-              JSONSchema.object(
-                  properties: [
-                      "date": .number(format: .double)
-                  ]
-              )
-          )
+        XCTAssertEqual(
+            node2,
+            JSONSchema.object(
+                properties: [
+                    "date": .number(format: .double)
+                ]
+            )
+        )
 
-          let e4 = JSONEncoder()
-          let df1 = DateFormatter()
-          df1.timeStyle = .none
-          e4.dateEncodingStrategy = .formatted(df1)
+        let e4 = JSONEncoder()
+        let df1 = DateFormatter()
+        df1.timeStyle = .none
+        e4.dateEncodingStrategy = .formatted(df1)
 
-          let node4 = try DateType.genericOpenAPISchemaGuess(using: e4)
+        let node4 = try DateType.genericOpenAPISchemaGuess(using: e4)
 
-          XCTAssertEqual(
-              node4,
-              JSONSchema.object(
-                  properties: [
-                      "date": .string(format: .date)
-                  ]
-              )
-          )
+        XCTAssertEqual(
+            node4,
+            JSONSchema.object(
+                properties: [
+                    "date": .string(format: .date)
+                ]
+            )
+        )
 
-          let e5 = JSONEncoder()
-          let df2 = DateFormatter()
-          df2.timeStyle = .full
-          e5.dateEncodingStrategy = .formatted(df2)
+        let e5 = JSONEncoder()
+        let df2 = DateFormatter()
+        df2.timeStyle = .full
+        e5.dateEncodingStrategy = .formatted(df2)
 
-          let node5 = try DateType.genericOpenAPISchemaGuess(using: e5)
+        let node5 = try DateType.genericOpenAPISchemaGuess(using: e5)
 
-          XCTAssertEqual(
-              node5,
-              JSONSchema.object(
-                  properties: [
-                      "date": .string(format: .dateTime)
-                  ]
-              )
-          )
-      #endif
+        XCTAssertEqual(
+            node5,
+            JSONSchema.object(
+                properties: [
+                    "date": .string(format: .dateTime)
+                ]
+            )
+        )
+        #endif
     }
 
     func test_nested() throws {


### PR DESCRIPTION
It looks like Swift 6.0 removed [the `DateEncodingStrategy.formatted(_)` case](https://github.com/apple/swift-foundation/blob/d7be92bd493ba8a1923e5675ca5a5cb68c156dc2/Sources/FoundationEssentials/JSON/JSONEncoder.swift#L55). This patches that and adds CI runs for newer versions of Ubuntu and Swift.

